### PR TITLE
Add build tool agnostic cmake command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ git submodule update
 mkdir build
 cd build
 cmake ..
+cmake --build .
 ```
 
 Your build directory should now contain requisite files for building on your current platform. On Windows, for example, you should find a `.sln` Visual Studio Solution file. On macOS/Linux, you should find a `make` file.


### PR DESCRIPTION
This 'cmake --build' flag abstracts a native build tool’s command-line interface to allow running the same command regardless of the native Operating System build tool.

Reference: https://cmake.org/cmake/help/v3.17/manual/cmake.1.html#build-a-project